### PR TITLE
doc README improve

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,32 +10,35 @@
 # <div align="center">VM-Series Azure Terraform Templates</div>
 
 ## :question: Overview
+
 This repository deploys all the components of a Transit-VNET topoloy using Palo Alto VM-Series Next Generation Firewalls and Panorama.
 
-## :rabbit2: Quickstart  
-1. [Install Terraform](https://www.terraform.io/downloads.html)
+## :rabbit2: Quickstart
+
+1. [Install Terraform 0.13](https://www.terraform.io/downloads.html)
 2. [Install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
 3. [Download and extract the latest bundle for your OS](https://github.com/adambaumeister/azure-vmseries-terraform/releases/latest)
-4. From the command line (or powershell, or Bash or whatever...) CD to the newly extracted directory.
+4. From the command line (or powershell, or Bash or whatever...) change directory to the newly extracted one
 5. Login to Azure
-```
+
+```bash
 az login
 ```
-5. Correctly populate the variables in the vars file example.tfvars
-6. Init terraform
-```
+
+6. Populate the variables in file `example.tfvars`
+7. Initialize and apply!
+
+```bash
 terraform init
-```
-7. Apply!
-```
-terraform apply --var-file=example.tfvars 
+terraform apply --var-file=example.tfvars
 ```
 
 ## :scroll: Documentation
-To know post-provisioning steps and for help standing up Panorama, [click here](https://adambaumeister.github.io/azure-vmseries-terraform/panorama.html)
 
-For more detailed documentation including the network topology and more, proceed to [Detailed Documentation](https://adambaumeister.github.io/azure-vmseries-terraform/index)
+For post-provisioning steps and for setting up the Panorama, [click here](https://adambaumeister.github.io/azure-vmseries-terraform/panorama.html).
+
+For the network topology and more, proceed to the [Detailed Documentation](https://adambaumeister.github.io/azure-vmseries-terraform/index).
 
 ## :beetle: Getting help
-[Open an Issue on Github](https://github.com/adambaumeister/azure-vmseries-terraform/issues)
 
+[Open an issue](https://github.com/adambaumeister/azure-vmseries-terraform/issues) on Github.

--- a/example.tfvars
+++ b/example.tfvars
@@ -1,11 +1,11 @@
-# IP : SG Rule priority map
-# Each Key is the public IP, and the number is the priority it gets in the relevant SGs
+# Priority map of security rules for your management IP addresses.
+# Each key is the public IP, and the number is the priority it gets in the relevant network security groups (NSGs).
 management_ips = {
   "199.199.199.199": 100,
 }
 
-# LB Rules
-# These are optional, but will automatically create a PIP and inbound LB configuration.
+# Optional Load Balancer (LB) rules
+# These will automatically create a public Azure IP and associate to LB configuration.
 rules = [
   {
     port = 22


### PR DESCRIPTION
Add empty lines after headers. Simplify/format text.
Mention version 0.13 explicitly, doesn't work with 0.12.