### PR TITLE
fix modules/panorama local-exec quotes

### DIFF
--- a/modules/panorama/panorama.tf
+++ b/modules/panorama/panorama.tf
@@ -57,6 +57,6 @@ resource "azurerm_virtual_machine" "panorama" {
     publisher = "paloaltonetworks"
   }
   provisioner "local-exec" {
-    command = "${path.cwd}/${path.module}/configure_panorama.exe -u ${var.username} -p ${var.password} -pip ${azurerm_network_interface.mgmt.private_ip_address} -pp ${azurerm_public_ip.panorama-pip-mgmt.ip_address} -sk ${azurerm_storage_account.bootstrap-storage-account.primary_access_key} -oss ${azurerm_storage_share.outbound-bootstrap-storage-share.name} -iss ${azurerm_storage_share.inbound-bootstrap-storage-share.name} -sn ${azurerm_storage_account.bootstrap-storage-account.name}"
+    command = "${path.root}/venv/bin/python ${path.root}/external/configure_panorama.py -u '${var.username}' -p '${var.password}' -pip ${azurerm_network_interface.mgmt.private_ip_address} -pp ${azurerm_public_ip.panorama-pip-mgmt.ip_address} -sk ${azurerm_storage_account.bootstrap-storage-account.primary_access_key} -oss ${azurerm_storage_share.outbound-bootstrap-storage-share.name} -iss ${azurerm_storage_share.inbound-bootstrap-storage-share.name} -sn ${azurerm_storage_account.bootstrap-storage-account.name}"
   }
 }


### PR DESCRIPTION
Passwords often contain special characters. This fixes all these cases except `'` single quote, which doesn't look trivial to do.