### PR TITLE
fix 7691 use azurerm version 2.24

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,9 @@
 # Configure the Azure provider
 provider "azurerm" {
   # whilst the `version` attribute is optional, we recommend pinning to a given version of the Provider
-  version = "=2.20.0"
+  version = "=2.24.0"
   features {}
 }
-
 
 # Setup all the networks required for the topology
 module "networks" {


### PR DESCRIPTION
Fix intermittent bug `DuplicateIpConfigurationReferenceOnBackendAddressPool`
that sometimes aborts `terraform destroy`. The bug:
https://github.com/terraform-providers/terraform-provider-azurerm/issues/7691