### PR TITLE
fix for deprecation warnings

### DIFF
--- a/modules/networks/networks.tf
+++ b/modules/networks/networks.tf
@@ -22,7 +22,7 @@ resource "azurerm_subnet_network_security_group_association" "panorama-mgmt-sa" 
 }
 resource "azurerm_subnet" "subnet-panorama-mgmt" {
   name                 = "${var.name_prefix}${var.sep}${var.name_panorama_subnet_mgmt}"
-  address_prefix       = "${var.management_vnet_prefix}${var.management_subnet}"
+  address_prefixes     = ["${var.management_vnet_prefix}${var.management_subnet}"]
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet-panorama-mgmt.name
 }
@@ -37,7 +37,7 @@ resource "azurerm_virtual_network" "vnet-vmseries" {
 # Management for VM-series
 resource "azurerm_subnet" "subnet-mgmt" {
   name                 = "${var.name_prefix}${var.sep}${var.name_subnet_mgmt}"
-  address_prefix       = "${var.firewall_vnet_prefix}${var.vm_management_subnet}"
+  address_prefixes     = ["${var.firewall_vnet_prefix}${var.vm_management_subnet}"]
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet-vmseries.name
 
@@ -55,7 +55,7 @@ resource "azurerm_subnet_network_security_group_association" "mgmt-sa" {
 # private network - don't need NSG here?
 resource "azurerm_subnet" "subnet-inside" {
   name                 = "${var.name_prefix}${var.sep}${var.name_subnet_inside}"
-  address_prefix       = "${var.firewall_vnet_prefix}${var.private_subnet}"
+  address_prefixes     = ["${var.firewall_vnet_prefix}${var.private_subnet}"]
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet-vmseries.name
 }
@@ -68,7 +68,7 @@ resource "azurerm_network_security_group" "sg-allowall" {
 }
 resource "azurerm_subnet" "subnet-outside" {
   name                 = "${var.name_prefix}${var.sep}${var.name_subnet_outside}"
-  address_prefix       = "${var.firewall_vnet_prefix}${var.public_subnet}"
+  address_prefixes     = ["${var.firewall_vnet_prefix}${var.public_subnet}"]
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet-vmseries.name
 }

--- a/modules/test-vnet/testhost.tf
+++ b/modules/test-vnet/testhost.tf
@@ -26,7 +26,7 @@ resource "azurerm_subnet" "subnet" {
   name                 = "${var.name_prefix}-testhost-subnet"
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet.name
-  address_prefix       = "10.100.100.0/26"
+  address_prefixes     = ["10.100.100.0/26"]
 }
 
 # Create Network Security Group and rule

--- a/modules/test-vnet/testhost.tf
+++ b/modules/test-vnet/testhost.tf
@@ -95,7 +95,7 @@ resource "tls_private_key" "example_ssh" {
   rsa_bits  = 4096
 }
 output "tls_private_key" {
-  value = "${tls_private_key.example_ssh.private_key_pem}"
+  value = tls_private_key.example_ssh.private_key_pem
 }
 
 # Create virtual machine


### PR DESCRIPTION
Terraform warned about:
- address_prefix deprecated in favor of address_prefixes list
- interpolation only syntax